### PR TITLE
add hatch and taskfile to manage scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,4 +1,24 @@
 # Custom Scripts Library
 
 ## Overview
-Custom code written by our customers for the purpose of integrating with OpsLevel. For example, you might find scripts for importing service dependency mapping from a third party tool, extending our Jira integration to automatically create Jira tickets from Campaign Checks, or populating your software catalog with infrastructure resources from GCP.
+Custom code written by our customers for the purpose of integrating with OpsLevel.
+For example, you might find scripts for importing service dependency mapping from
+a third party tool, extending our Jira integration to automatically create Jira
+tickets from Campaign Checks, or populating your software catalog with
+infrastructure resources from GCP.
+
+### Taskfile tasks
+
+[Taskfile](https://taskfile.dev/) tasks can be used to lint, format, test, and run
+scripts found in this directory.
+With [task installed](https://taskfile.dev/installation/) run `task --list` for examples.
+
+### Python Scripts
+
+Create Campaign Jira Issues.
+- [./create_campaign_jira_issues/](./create_campaign_jira_issues/)
+
+### Ruby Scripts
+
+Import GCP infrastructure into your OpsLevel account.
+- [./gcp_infrastructure_import/](./gcp_infrastructure_import/)

--- a/scripts/Taskfile.yml
+++ b/scripts/Taskfile.yml
@@ -1,0 +1,46 @@
+# https://taskfile.dev/
+
+version: '3'
+
+tasks:
+
+  lint:
+    desc: Check formatting and linting
+    cmds:
+      - echo "Checking formatting and linting for Python scripts..."
+      - hatch run lint
+      - echo "Checking formatting and linting for Ruby scripts..."
+      - echo "None configured yet."
+    preconditions:
+    - sh: 'which hatch'
+      msg: '"hatch" manages the virtualenv to lint code - run "pip install hatch"'
+
+  lintfix:
+    desc: Fix formatting and linting
+    cmds:
+      - echo "Fixing formatting and linting for Python scripts..."
+      - hatch run lint-fix
+      - echo "Fixing formatting and linting for Ruby scripts..."
+      - echo "None configured yet."
+    preconditions:
+    - sh: 'which hatch'
+      msg: '"hatch" manages the virtualenv to fix code - run "pip install hatch"'
+
+  setup:
+    desc: Setup tools needed to use scripts
+    cmds:
+      - echo "Running setup needed to use Python scripts..."
+      - pip --quiet install hatch
+      - echo "Running setup needed to use Ruby scripts..."
+      - echo "None configured yet."
+
+  test:
+    desc: Run tests found in scripts directory
+    cmds:
+      - echo "Running tests for Python scripts..."
+      - hatch run test || exit 0
+      - echo "Running tests for Ruby scripts..."
+      - echo "None configured yet."
+    preconditions:
+    - sh: 'which hatch'
+      msg: '"hatch" manages the virtualenv to test code - run "pip install hatch"'

--- a/scripts/create_campaign_jira_issues/requirements.txt
+++ b/scripts/create_campaign_jira_issues/requirements.txt
@@ -1,4 +1,4 @@
-python-dotenv
-requests
-rich
-typer
+python-dotenv == 1.0.0
+requests == 2.31
+rich == 13.6
+typer == 0.0.13

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,0 +1,59 @@
+[project]
+name = "OpsLevel-community-integrations-scripts"
+version = "0.0.1"
+description = "Custom Python scripts written by the OpsLevel community"
+dynamic = ["optional-dependencies"]
+requires-python = ">=3.11"
+
+[project.urls]
+Source = "https://github.com/OpsLevel/community-integrations"
+Documentation = "https://github.com/OpsLevel/community-integrations/tree/main/scripts#readme"
+
+[tool.hatch.metadata.hooks.requirements_txt.optional-dependencies]
+create_campaign_jira_issues_dependencies = [
+  "create_campaign_jira_issues/requirements.txt",
+]
+
+[tool.hatch.envs.default]
+description = "Linting, formatting, and testing files"
+dependencies = [
+  "black~=23.10",
+  "pytest~=7.3",
+  "ruff~=0.1.3",
+]
+
+[tool.hatch.envs.default.scripts]
+lint = [
+  "black --check {env:GITHUB_ACTION_PATH:{root}}",
+  "ruff {env:GITHUB_ACTION_PATH:{root}}",
+]
+lint-fix = [
+  "black {env:GITHUB_ACTION_PATH:{root}}",
+  "ruff --fix {env:GITHUB_ACTION_PATH:{root}}",
+]
+test = [
+  "pytest --capture=sys {env:GITHUB_ACTION_PATH:{root}}",
+]
+
+[tool.hatch.envs.create_campaign_jira_issues]
+description = "Creates JIRA issues tied to a campaign"
+template = "create_campaign_jira_issues"
+features = ["create_campaign_jira_issues_dependencies"]
+
+[tool.hatch.envs.create_campaign_jira_issues.scripts]
+run = [
+  "python create_campaign_jira_issues/create_campaign_jira_issues.py",
+]
+debug = [
+  "python -m pdb create_campaign_jira_issues/create_campaign_jira_issues.py",
+]
+
+[tool.ruff]
+ignore = ["E501"]
+src = [
+  "{env:GITHUB_ACTION_PATH:{root}}",
+]
+
+[build-system]
+requires = ["hatchling", "hatch-requirements-txt"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
# Goal of this PR
To create a common entry point for each new script that customers contribute.

## Taskfile
For consistency with most other open source OpsLevel repos we have a `Taskfile.yml` that defines `tasks`. This is based on Golang but acts as a language agnostic catch all for Python, Ruby, etc. much like a `Makefile` would.
- `task lint` for instance could run a Python linter on all Python scripts and a Ruby linter on Ruby scripts.

## Python scripts and Hatch

For Python scripts we can use [hatch](https://hatch.pypa.io/) to manage each script in its own directory.
- Hatch separates each script (or package for more complex cases) into an isolated virtualenv. See `[tool.hatch.envs.create_campaign_jira_issues]` in `pyproject.toml`.
- The `create_campaign_jira_issues` virtualenv also has easily runnable scripts. See `[tool.hatch.envs.create_campaign_jira_issues.scripts]`.
  - Running `hatch run create_campaign_jira_issues:debug` for instance - creates a new virtualenv, install dependencies from `./create_campaign_jira_issues/requirements.txt` into that virtualenv, and runs `python -m pdb create_campaign_jira_issues/create_campaign_jira_issues.py` allowing a user to debug this script with one quick command.
  - Running `hatch run create_campaign_jira_issues:run` simply runs the script after setting up a virtualenv as described above.
- Running `hatch run lint` will check all python code in `./scripts/` for linting and formatting errors. This is nested in `task lint`. 