### PR TITLE
opslevelsignature: add go example

### DIFF
--- a/scripts/verify_opslevel_webhook_signature/go/go.mod
+++ b/scripts/verify_opslevel_webhook_signature/go/go.mod
@@ -1,0 +1,3 @@
+module opslevelsignature
+
+go 1.20

--- a/scripts/verify_opslevel_webhook_signature/go/go.mod
+++ b/scripts/verify_opslevel_webhook_signature/go/go.mod
@@ -1,3 +1,3 @@
 module opslevelsignature
 
-go 1.20
+go 1.23

--- a/scripts/verify_opslevel_webhook_signature/go/main.go
+++ b/scripts/verify_opslevel_webhook_signature/go/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+var (
+	secret string = "OpslevelWebhookSecret"
+)
+
+func main() {
+	// Handler function for the root path ("/")
+	http.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
+		hmacSig, err := GetSignatureFromHeader(r.Header)
+		if err != nil {
+			panic(err)
+		}
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+
+		content, err := BuildContent(r.Header, nil, b)
+		if err != nil {
+			panic(err)
+		}
+		computedSig, match := Verify(content, hmacSig, secret)
+		if !match {
+			fmt.Printf("Signature does _not_ match!\n")
+		} else {
+			fmt.Printf("Signature match!\n")
+		}
+		fmt.Printf("Signature received in header: '%s'\n", hmacSig)
+		fmt.Printf("Signature computed from payload: '%s'\n", computedSig)
+		fmt.Printf("Pyaload content: '%s'\n", content)
+	})
+
+	// Start the server listening on port 8080
+	fmt.Println("Server listening on http://localhost:8080/webhook")
+	fmt.Println("Execute this for testing\n\ncurl -H 'X-Opslevel-Timing: 123456' -H 'X-Opslevel-Signature: sha256=ee9eac178fe5cd260ff1d6f9fedcc409c6389ea5718ec44c8e266c6128770233' localhost:8080/webhook")
+	http.ListenAndServe(":8080", nil)
+}

--- a/scripts/verify_opslevel_webhook_signature/go/main.go
+++ b/scripts/verify_opslevel_webhook_signature/go/main.go
@@ -11,7 +11,6 @@ var (
 )
 
 func main() {
-	// Handler function for the root path ("/")
 	http.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
 		hmacSig, err := GetSignatureFromHeader(r.Header)
 		if err != nil {
@@ -37,7 +36,6 @@ func main() {
 		fmt.Printf("Pyaload content: '%s'\n", content)
 	})
 
-	// Start the server listening on port 8080
 	fmt.Println("Server listening on http://localhost:8080/webhook")
 	fmt.Println("Execute this for testing\n\ncurl -H 'X-Opslevel-Timing: 123456' -H 'X-Opslevel-Signature: sha256=ee9eac178fe5cd260ff1d6f9fedcc409c6389ea5718ec44c8e266c6128770233' localhost:8080/webhook")
 	http.ListenAndServe(":8080", nil)

--- a/scripts/verify_opslevel_webhook_signature/go/signature.go
+++ b/scripts/verify_opslevel_webhook_signature/go/signature.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+const (
+	HeaderSignatureCanonical = "X-Opslevel-Signature"
+	HeaderSignature          = "X-OpsLevel-Signature"
+	HeaderTimingCanonical    = "X-Opslevel-Timing"
+	HeaderTiming             = "X-OpsLevel-Timing"
+)
+
+// Search for
+func GetSignatureFromHeader(headers http.Header) (string, error) {
+	if headers[HeaderSignatureCanonical] == nil {
+		return "", fmt.Errorf("missing header '%s'", HeaderSignatureCanonical)
+	}
+	return headers[HeaderSignatureCanonical][0], nil
+}
+
+func BuildContent(headers http.Header, additionalHeadersToKeep []string, body []byte) (string, error) {
+	if headers[HeaderTimingCanonical] == nil {
+		return "", fmt.Errorf("missing header '%s'", HeaderTimingCanonical)
+	}
+
+	// Build the headers for signature verification
+	keys := append([]string{HeaderTiming}, additionalHeadersToKeep...) // Make sure we always have X-Opslevel-Timing in there
+	sort.Strings(keys)
+
+	// Create the header content portion
+	headerContent := []string{}
+	for _, k := range keys {
+		headerContent = append(headerContent, k+":"+headers[http.CanonicalHeaderKey(k)][0])
+	}
+	h := strings.Join(headerContent, ",")
+
+	// Build content
+	return fmt.Sprintf("%s+%s", h, string(body[:])), nil
+}
+
+func Verify(content string, hmacSig string, secret string) (string, bool) {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(content))
+	computedSig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if computedSig != hmacSig {
+		return computedSig, false
+	}
+	return computedSig, true
+}

--- a/scripts/verify_opslevel_webhook_signature/go/signature.go
+++ b/scripts/verify_opslevel_webhook_signature/go/signature.go
@@ -17,7 +17,7 @@ const (
 	HeaderTiming             = "X-OpsLevel-Timing"
 )
 
-// Search for opslevle signature
+// Search for OpsLevel signature
 func GetSignatureFromHeader(headers http.Header) (string, error) {
 	if headers[HeaderSignatureCanonical] == nil {
 		return "", fmt.Errorf("missing header '%s'", HeaderSignatureCanonical)

--- a/scripts/verify_opslevel_webhook_signature/go/signature.go
+++ b/scripts/verify_opslevel_webhook_signature/go/signature.go
@@ -17,7 +17,7 @@ const (
 	HeaderTiming             = "X-OpsLevel-Timing"
 )
 
-// Search for
+// Search for opslevle signature
 func GetSignatureFromHeader(headers http.Header) (string, error) {
 	if headers[HeaderSignatureCanonical] == nil {
 		return "", fmt.Errorf("missing header '%s'", HeaderSignatureCanonical)
@@ -25,6 +25,7 @@ func GetSignatureFromHeader(headers http.Header) (string, error) {
 	return headers[HeaderSignatureCanonical][0], nil
 }
 
+// Build the content to be signed
 func BuildContent(headers http.Header, additionalHeadersToKeep []string, body []byte) (string, error) {
 	if headers[HeaderTimingCanonical] == nil {
 		return "", fmt.Errorf("missing header '%s'", HeaderTimingCanonical)
@@ -45,6 +46,7 @@ func BuildContent(headers http.Header, additionalHeadersToKeep []string, body []
 	return fmt.Sprintf("%s+%s", h, string(body[:])), nil
 }
 
+// Verify that the content match the hmacSig.
 func Verify(content string, hmacSig string, secret string) (string, bool) {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(content))

--- a/scripts/verify_opslevel_webhook_signature/go/signature_test.go
+++ b/scripts/verify_opslevel_webhook_signature/go/signature_test.go
@@ -106,9 +106,6 @@ func TestVerify(t *testing.T) {
 	if computedSig != headers[HeaderSignatureCanonical][0] {
 		t.Errorf("computed signature should be equal to header signature, expected: '%s', received: '%s'", computedSig, headers[HeaderSignatureCanonical][0])
 	}
-	if err != nil {
-		t.Fatalf("there should be no error: %s", err)
-	}
 }
 
 func TestGetContentErrors(t *testing.T) {

--- a/scripts/verify_opslevel_webhook_signature/go/signature_test.go
+++ b/scripts/verify_opslevel_webhook_signature/go/signature_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestGetSignatureFromHeader(t *testing.T) {
+	headers := make(http.Header)
+	_, err := GetSignatureFromHeader(headers)
+	if err == nil {
+		t.Error("expecting error")
+	}
+
+	headers[HeaderSignatureCanonical] = []string{"sha256=ab238ca1f60b94dbf50e7b237baf0dc93f02e4ff21736d549f9625d5300f962b"}
+	hmacSig, _ := GetSignatureFromHeader(headers)
+	if hmacSig != headers[HeaderSignatureCanonical][0] {
+		t.Errorf("received sig is different, expected: '%s', received: '%s'", headers[HeaderSignatureCanonical][0], hmacSig)
+	}
+}
+func TestGetContent(t *testing.T) {
+	headers := make(http.Header)
+	headers[HeaderTimingCanonical] = []string{"1726164245"}
+	headers[HeaderSignatureCanonical] = []string{"sha256=ab238ca1f60b94dbf50e7b237baf0dc93f02e4ff21736d549f9625d5300f962b"}
+	content, err := BuildContent(headers, nil, []byte{})
+
+	expectedContent := fmt.Sprintf("%s:%s+", HeaderTiming, headers[HeaderTimingCanonical][0])
+	if content != expectedContent {
+		t.Errorf("content ('%s') is not what is expected ('%s')", content, expectedContent)
+	}
+
+	if err != nil {
+		t.Errorf("there should be no error: %s", err)
+	}
+}
+
+func TestGetContentMultiHeader(t *testing.T) {
+	headers := make(http.Header)
+	headers[HeaderTimingCanonical] = []string{"1726164245"}
+	headers[HeaderSignatureCanonical] = []string{"sha256=ab238ca1f60b94dbf50e7b237baf0dc93f02e4ff21736d549f9625d5300f962b"}
+	headers["Anotherheader-Signature"] = []string{"somevalue"}
+
+	content, err := BuildContent(headers, []string{"Anotherheader-Signature"}, []byte{})
+
+	expectedContent := fmt.Sprintf("Anotherheader-Signature:%s,%s:%s+", headers["Anotherheader-Signature"][0], HeaderTiming, headers[HeaderTimingCanonical][0])
+	if content != expectedContent {
+		t.Errorf("content ('%s') is not what is expected ('%s')", content, expectedContent)
+	}
+
+	if err != nil {
+		t.Errorf("there should be no error: %s", err)
+	}
+}
+
+func TestGetContentMultiHeaderWeirdLowercase(t *testing.T) {
+	headers := make(http.Header)
+	headers[HeaderTimingCanonical] = []string{"1726164245"}
+	headers[HeaderSignatureCanonical] = []string{"sha256=ab238ca1f60b94dbf50e7b237baf0dc93f02e4ff21736d549f9625d5300f962b"}
+	headers["Anotherheader-Signature"] = []string{"somevalue"}
+
+	content, err := BuildContent(headers, []string{"anotherheader-Signature"}, []byte{})
+
+	expectedContent := fmt.Sprintf("X-OpsLevel-Timing:%s,anotherheader-Signature:%s+", headers[HeaderTimingCanonical][0], headers["Anotherheader-Signature"][0])
+	if content != expectedContent {
+		t.Errorf("content ('%s') is not what is expected ('%s')", content, expectedContent)
+	}
+
+	if err != nil {
+		t.Errorf("there should be no error: %s", err)
+	}
+}
+
+func TestGetContentMultiHeaderMissing(t *testing.T) {
+	headers := make(http.Header)
+	headers[HeaderTimingCanonical] = []string{"1726164245"}
+	headers[HeaderSignatureCanonical] = []string{"sha256=ab238ca1f60b94dbf50e7b237baf0dc93f02e4ff21736d549f9625d5300f962b"}
+	headers["Anotherheader-Signature"] = []string{"somevalue"}
+
+	// Test non-canonical header
+	content, err := BuildContent(headers, nil, []byte{})
+
+	expectedContent := fmt.Sprintf("X-OpsLevel-Timing:%s+", headers[HeaderTimingCanonical][0])
+	if content != expectedContent {
+		t.Errorf("content ('%s') is not what is expected ('%s')", content, expectedContent)
+	}
+
+	if err != nil {
+		t.Errorf("there should be no error: %s", err)
+	}
+}
+
+func TestVerify(t *testing.T) {
+	headers := make(http.Header)
+	headers[HeaderTimingCanonical] = []string{"1726164245"}
+	headers[HeaderSignatureCanonical] = []string{"sha256=89649e9d66e0f48c8a6e67fc12197d68dbcb91710391555fcf3a59d8757bf63b"}
+	content, err := BuildContent(headers, nil, []byte{})
+	if err != nil {
+		t.Fatalf("there should be no error on GetContent: %s", err)
+	}
+	hmacSig, err := GetSignatureFromHeader(headers)
+	if err != nil {
+		t.Fatalf("there should be no error on GetSignatureFromHeader: %s", err)
+	}
+	computedSig, _ := Verify(content, hmacSig, "somesecrethere")
+	if computedSig != headers[HeaderSignatureCanonical][0] {
+		t.Errorf("computed signature should be equal to header signature, expected: '%s', received: '%s'", computedSig, headers[HeaderSignatureCanonical][0])
+	}
+	if err != nil {
+		t.Fatalf("there should be no error: %s", err)
+	}
+}
+
+func TestGetContentErrors(t *testing.T) {
+	headers := make(http.Header)
+	headers[HeaderSignatureCanonical] = []string{"sha256=66eec7a940647ad571944363d4e044e6b39a687c1df8b0808f86b8a4ea085d6e"}
+
+	content, err := BuildContent(headers, nil, []byte{})
+	if err == nil {
+		t.Errorf("should have received '%s' missing header errors", HeaderTimingCanonical)
+	}
+	if content != "" {
+		t.Errorf("content should be '\"\"', got '%s'", content)
+	}
+
+	headers[HeaderTimingCanonical] = []string{"1726164245"}
+	_, err = BuildContent(headers, nil, []byte{})
+	if err != nil {
+		t.Errorf("should not return any error: %s", err)
+	}
+}


### PR DESCRIPTION
This add a golang example on how to verify opslevel signature