### PR TITLE
Improve opslevel.yml export with selective component type downloads.

### DIFF
--- a/scripts/export_all_opslevel_yml/.gitignore
+++ b/scripts/export_all_opslevel_yml/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+opslevelyml_repo/
+skipped_components_with_missing_repo_links.txt
+example_componenttypes_output.json

--- a/scripts/export_all_opslevel_yml/README.md
+++ b/scripts/export_all_opslevel_yml/README.md
@@ -1,12 +1,31 @@
 # Export opslevel.yml files for all services
 
 This script is designed to export the auto-generated opslevel.yml contents for
-each service in your OpsLevel account. The contents are written to file as:
-"service name"_opslevel.yml.
+each service in your OpsLevel account. The contents are written to:
+
+```
+opslevelyml_repo/<componentType>/<service_slug>/opslevel.yml
+```
+
+For example:
+
+```
+opslevelyml_repo/service/shopping_cart_service/opslevel.yml
+opslevelyml_repo/backend/fraud_detection_service/opslevel.yml
+```
 
 The script can be updated to push/copy the opslevel.yml file to the 
 coresponding service's repo (and maybe automatically open a pull/merge request)
 in the git repository.
+
+The script excludes the `properties:` section from exported YAML by default. Use
+`--include properties` to keep it.
+
+Components without a linked repository are skipped. Their OpsLevel `htmlUrl` is
+written to `skipped_components_with_missing_repo_links.txt`.
+
+Use `--dry-run` to preview which components would be exported without writing
+`opslevelyml_repo/`. The skipped-components file is still written in dry-run mode.
 
 Requirements:
 
@@ -16,8 +35,40 @@ Requirements:
 To run this:
 
 1. Add your api token to an `OPSLEVEL_API_TOKEN` environment variable
-2. Execute the commands below. 
+2. Execute the script. You will be prompted to select which component types to export.
+3. Execute the commands below.
 
 ```bash
 python ./opslevel_yml_export_for_all_services.py
+python ./opslevel_yml_export_for_all_services.py --include properties
+python ./opslevel_yml_export_for_all_services.py --dry-run
+```
+
+When prompted, enter comma-separated numbers for the component types you want,
+or `a` to export all default component types.
+
+Example:
+
+```
+python ./opslevel_yml_export_for_all_services.py
+
+Select component type(s) to export opslevel.yml for (comma-separated numbers, or enter 'a' for all):
+1. api
+2. application
+3. archived_component
+4. backend
+5. frontend
+6. jira_ticket
+7. library
+8. mobile_app
+9. service
+10. team_checks
+11. third_party_vendors
+12. unowned_repo
+> 1,2,4,5,7,8,9,11
+
+Exporting opslevel.yml for: api, application, backend, frontend, library, mobile_app, service, third_party_vendors
+
+Exported 24 component(s) to /export_all_opslevel_yml/opslevelyml_repo.
+Skipped 57 component(s) with no linked repo. See /export_all_opslevel_yml/skipped_components_with_missing_repo_links.txt.
 ```

--- a/scripts/export_all_opslevel_yml/README.md
+++ b/scripts/export_all_opslevel_yml/README.md
@@ -21,11 +21,13 @@ in the git repository.
 The script excludes the `properties:` section from exported YAML by default. Use
 `--include properties` to keep it.
 
-Components without a linked repository are skipped. Their OpsLevel `htmlUrl` is
-written to `skipped_components_with_missing_repo_links.txt`.
+Components without a linked repository are skipped by default. Their OpsLevel
+`htmlUrl` is written to `skipped_components_with_missing_repo_links.txt`. Use
+`--include-no-repo` to export those components as well.
 
 Use `--dry-run` to preview which components would be exported without writing
-`opslevelyml_repo/`. The skipped-components file is still written in dry-run mode.
+`opslevelyml_repo/`. The skipped-components file is still written in dry-run mode
+unless `--include-no-repo` is set.
 
 Requirements:
 
@@ -35,13 +37,15 @@ Requirements:
 To run this:
 
 1. Add your api token to an `OPSLEVEL_API_TOKEN` environment variable
-2. Execute the script. You will be prompted to select which component types to export.
-3. Execute the commands below.
+2. Run the script. You will be prompted to select which component types to export,
+   unless you pass `--component-types` for non-interactive use.
 
 ```bash
 python ./opslevel_yml_export_for_all_services.py
 python ./opslevel_yml_export_for_all_services.py --include properties
 python ./opslevel_yml_export_for_all_services.py --dry-run
+python ./opslevel_yml_export_for_all_services.py --include-no-repo
+python ./opslevel_yml_export_for_all_services.py --component-types service backend frontend
 ```
 
 When prompted, enter comma-separated numbers for the component types you want,
@@ -50,7 +54,7 @@ or `a` to export all default component types.
 Example:
 
 ```
-python ./opslevel_yml_export_for_all_services.py
+python opslevel_yml_export_for_all_services.py
 
 Select component type(s) to export opslevel.yml for (comma-separated numbers, or enter 'a' for all):
 1. api

--- a/scripts/export_all_opslevel_yml/opslevel_yml_export_for_all_services.py
+++ b/scripts/export_all_opslevel_yml/opslevel_yml_export_for_all_services.py
@@ -1,4 +1,5 @@
 import argparse
+import contextlib
 import os
 import sys
 
@@ -17,7 +18,6 @@ COMPONENT_TYPES_QUERY = """
     query componentTypes($endCursor: String) {
         account {
             componentTypes(after: $endCursor) {
-                totalCount
                 pageInfo {
                     hasNextPage
                     endCursor
@@ -36,8 +36,6 @@ LIST_SERVICES_QUERY = """
     query services($endCursor: String) {
         account {
             services(componentCategory: "default", after: $endCursor) {
-                totalCount
-                filteredCount
                 pageInfo {
                     hasNextPage
                     endCursor
@@ -74,7 +72,6 @@ FETCH_OPSLEVEL_YML_FOR_SERVICE_QUERY = """
 """
 
 
-# Function to make a GraphQL query
 def opslevel_graphql_query(query, variables=None):
     headers = {
         "Content-Type": "application/json",
@@ -82,7 +79,26 @@ def opslevel_graphql_query(query, variables=None):
     }
     data = {"query": query, "variables": variables}
     response = requests.post(OPSLEVEL_ENDPOINT, json=data, headers=headers)
-    return response.json()
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise RuntimeError(
+            f"OpsLevel API request failed with HTTP {response.status_code}: "
+            f"{response.text}"
+        ) from exc
+
+    payload = response.json()
+    if errors := payload.get("errors"):
+        messages = "; ".join(
+            error.get("message", str(error)) for error in errors
+        )
+        raise RuntimeError(f"OpsLevel GraphQL error: {messages}")
+
+    if not payload.get("data"):
+        raise RuntimeError(f"OpsLevel API returned no data: {payload}")
+
+    return payload
 
 
 def fetch_default_component_types():
@@ -148,24 +164,59 @@ def has_linked_repo(node):
     return any(repo.get("id") for repo in repo_nodes)
 
 
-def export_opslevel_yml_files(selected_aliases, excluded_sections, dry_run=False):
+def get_component_type_alias(node):
+    component_type = node.get("type") or {}
+    return component_type.get("alias")
+
+
+def write_opslevel_yml_for_component(node, component_type, excluded_sections):
+    service_slug = node["slug"]
+    service_id = node["id"]
+    response = opslevel_graphql_query(
+        FETCH_OPSLEVEL_YML_FOR_SERVICE_QUERY, variables={"id": service_id}
+    )
+    yaml_data = response["data"]["account"]["configFile"]["yaml"]
+    yaml_data = post_process_opslevel_yml(yaml_data, excluded_sections)
+    output_dir = os.path.join(OUTPUT_BASE_DIR, component_type, service_slug)
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.join(output_dir, "opslevel.yml")
+    with open(output_path, "w") as f:
+        f.write(yaml_data)
+
+
+def export_opslevel_yml_files(
+    selected_aliases, excluded_sections, dry_run=False, include_no_repo=False
+):
     end_cursor = None
     has_next_page = True
     skipped_count = 0
+    skipped_no_type_count = 0
+    no_repo_exported_count = 0
     exported_count = 0
 
-    with open(SKIPPED_COMPONENTS_FILE, "w") as skipped_file:
+    skipped_file_context = (
+        open(SKIPPED_COMPONENTS_FILE, "w")
+        if not include_no_repo
+        else contextlib.nullcontext()
+    )
+
+    with skipped_file_context as skipped_file:
         while has_next_page:
             response = opslevel_graphql_query(
                 LIST_SERVICES_QUERY, variables={"endCursor": end_cursor}
             )
             nodes = response["data"]["account"]["services"]["nodes"]
             for node in nodes:
-                component_type = node["type"]["alias"]
+                component_type = get_component_type_alias(node)
+                if not component_type:
+                    skipped_no_type_count += 1
+                    continue
+
                 if component_type not in selected_aliases:
                     continue
 
-                if not has_linked_repo(node):
+                missing_repo = not has_linked_repo(node)
+                if missing_repo and not include_no_repo:
                     skipped_file.write(f"{node['htmlUrl']}\n")
                     skipped_count += 1
                     continue
@@ -173,24 +224,18 @@ def export_opslevel_yml_files(selected_aliases, excluded_sections, dry_run=False
                 service_slug = node["slug"]
                 if dry_run:
                     exported_count += 1
+                    if missing_repo:
+                        no_repo_exported_count += 1
                     print(
                         f"[dry-run] Would export: "
                         f"{component_type}/{service_slug}/opslevel.yml"
                     )
                     continue
 
-                service_id = node["id"]
-                response_2 = opslevel_graphql_query(
-                    FETCH_OPSLEVEL_YML_FOR_SERVICE_QUERY, variables={"id": service_id}
-                )
-                yaml_data = response_2["data"]["account"]["configFile"]["yaml"]
-                yaml_data = post_process_opslevel_yml(yaml_data, excluded_sections)
-                output_dir = os.path.join(OUTPUT_BASE_DIR, component_type, service_slug)
-                os.makedirs(output_dir, exist_ok=True)
-                output_path = os.path.join(output_dir, "opslevel.yml")
-                with open(output_path, "w") as f:
-                    f.write(yaml_data)
+                write_opslevel_yml_for_component(node, component_type, excluded_sections)
                 exported_count += 1
+                if missing_repo:
+                    no_repo_exported_count += 1
 
             page_info = response["data"]["account"]["services"]["pageInfo"]
             has_next_page = page_info["hasNextPage"]
@@ -204,10 +249,20 @@ def export_opslevel_yml_files(selected_aliases, excluded_sections, dry_run=False
     else:
         print(f"\nExported {exported_count} component(s) to {OUTPUT_BASE_DIR}.")
 
-    if skipped_count:
+    if include_no_repo:
+        if no_repo_exported_count:
+            print(
+                f"Included {no_repo_exported_count} component(s) with no linked repo."
+            )
+    else:
         print(
             f"Skipped {skipped_count} component(s) with no linked repo. "
             f"See {SKIPPED_COMPONENTS_FILE}."
+        )
+
+    if skipped_no_type_count:
+        print(
+            f"Skipped {skipped_no_type_count} component(s) with no component type."
         )
 
 
@@ -215,6 +270,9 @@ def post_process_opslevel_yml(yaml_data, excluded_sections):
     if "properties" not in excluded_sections:
         return yaml_data
 
+    # Strip excluded sections line-by-line instead of parsing with a YAML library
+    # so OpsLevel's original formatting, key order, and comments are preserved.
+    # This assumes OpsLevel emits top-level keys with 2-space indentation.
     lines = yaml_data.splitlines(keepends=True)
     result = []
     i = 0
@@ -237,24 +295,63 @@ def post_process_opslevel_yml(yaml_data, excluded_sections):
     return "".join(result)
 
 
+def resolve_component_type_selection(component_types, component_type_args):
+    available_aliases = {component_type["alias"] for component_type in component_types}
+
+    if component_type_args is None:
+        return prompt_component_type_selection(component_types)
+
+    selected_aliases = set(component_type_args)
+    unknown_aliases = sorted(selected_aliases - available_aliases)
+    if unknown_aliases:
+        print(
+            "Unknown component type(s): "
+            f"{', '.join(unknown_aliases)}. "
+            f"Available: {', '.join(sorted(available_aliases))}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return selected_aliases
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Export OpsLevel opslevel.yml files for all components."
     )
     parser.add_argument(
+        "--component-types",
+        nargs="+",
+        metavar="ALIAS",
+        help=(
+            "Component type aliases to export (e.g. service backend). "
+            "Skips the interactive prompt."
+        ),
+    )
+    parser.add_argument(
         "--include",
         nargs="+",
-        choices=["properties"],
+        choices=sorted(DEFAULT_EXCLUDED_SECTIONS),
         default=[],
         metavar="SECTION",
         help="Include optional YAML sections in the export (default: properties are excluded)",
+    )
+    parser.add_argument(
+        "--include-no-repo",
+        action="store_true",
+        help=(
+            "Also export components with no linked repository. "
+            "By default these are skipped and written to "
+            "skipped_components_with_missing_repo_links.txt."
+        ),
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
         help=(
             "List components that would be exported without writing opslevel.yml files. "
-            "Still writes skipped_components_with_missing_repo_links.txt."
+            "Still writes skipped_components_with_missing_repo_links.txt unless "
+            "--include-no-repo is set."
         ),
     )
     return parser.parse_args()
@@ -270,11 +367,18 @@ def main():
         print("No component types with category 'default' were found.", file=sys.stderr)
         sys.exit(1)
 
-    selected_aliases = prompt_component_type_selection(component_types)
+    selected_aliases = resolve_component_type_selection(
+        component_types, args.component_types
+    )
     if args.dry_run:
         print("\n[dry-run] No opslevel.yml files will be written.")
     print(f"\nExporting opslevel.yml for: {', '.join(sorted(selected_aliases))}")
-    export_opslevel_yml_files(selected_aliases, excluded_sections, dry_run=args.dry_run)
+    export_opslevel_yml_files(
+        selected_aliases,
+        excluded_sections,
+        dry_run=args.dry_run,
+        include_no_repo=args.include_no_repo,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/export_all_opslevel_yml/opslevel_yml_export_for_all_services.py
+++ b/scripts/export_all_opslevel_yml/opslevel_yml_export_for_all_services.py
@@ -1,8 +1,77 @@
+import argparse
 import os
+import sys
+
 import requests
 
 OPSLEVEL_API_TOKEN = os.environ["OPSLEVEL_API_TOKEN"]
 OPSLEVEL_ENDPOINT = "https://app.opslevel.com/graphql"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+OUTPUT_BASE_DIR = os.path.join(SCRIPT_DIR, "opslevelyml_repo")
+SKIPPED_COMPONENTS_FILE = os.path.join(
+    SCRIPT_DIR, "skipped_components_with_missing_repo_links.txt"
+)
+DEFAULT_EXCLUDED_SECTIONS = {"properties"}
+
+COMPONENT_TYPES_QUERY = """
+    query componentTypes($endCursor: String) {
+        account {
+            componentTypes(after: $endCursor) {
+                totalCount
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+                nodes {
+                    id
+                    alias
+                    category
+                }
+            }
+        }
+    }
+"""
+
+LIST_SERVICES_QUERY = """
+    query services($endCursor: String) {
+        account {
+            services(componentCategory: "default", after: $endCursor) {
+                totalCount
+                filteredCount
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+                nodes {
+                    id
+                    name
+                    slug
+                    type {
+                        id
+                        alias
+                    }
+                    htmlUrl
+                    repos {
+                        nodes {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+FETCH_OPSLEVEL_YML_FOR_SERVICE_QUERY = """
+    query get_opslevel_yml($id: ID!) {
+        account {
+            configFile(id: $id) {
+                ownerType
+                yaml
+            }
+        }
+    }
+"""
 
 
 # Function to make a GraphQL query
@@ -16,61 +85,196 @@ def opslevel_graphql_query(query, variables=None):
     return response.json()
 
 
+def fetch_default_component_types():
+    end_cursor = None
+    has_next_page = True
+    component_types = []
+
+    while has_next_page:
+        response = opslevel_graphql_query(
+            COMPONENT_TYPES_QUERY, variables={"endCursor": end_cursor}
+        )
+        nodes = response["data"]["account"]["componentTypes"]["nodes"]
+        component_types.extend(
+            component_type
+            for component_type in nodes
+            if component_type["category"] == "default"
+        )
+        page_info = response["data"]["account"]["componentTypes"]["pageInfo"]
+        has_next_page = page_info["hasNextPage"]
+        end_cursor = page_info["endCursor"]
+
+    return component_types
+
+
+def prompt_component_type_selection(component_types):
+    print(
+        "\nSelect component type(s) to export opslevel.yml for "
+        "(comma-separated numbers, or enter 'a' for all):"
+    )
+    for index, component_type in enumerate(component_types, start=1):
+        print(f"{index}. {component_type['alias']}")
+
+    while True:
+        selection = input("> ").strip().lower()
+        if selection == "a":
+            return {component_type["alias"] for component_type in component_types}
+
+        try:
+            selected_indexes = [
+                int(value.strip()) for value in selection.split(",") if value.strip()
+            ]
+        except ValueError:
+            print("Invalid input. Enter comma-separated numbers or 'a' for all.")
+            continue
+
+        if not selected_indexes:
+            print("No component types selected. Try again.")
+            continue
+
+        if any(index < 1 or index > len(component_types) for index in selected_indexes):
+            print(f"Enter numbers between 1 and {len(component_types)}, or 'a' for all.")
+            continue
+
+        return {
+            component_types[index - 1]["alias"]
+            for index in selected_indexes
+        }
+
+
+def has_linked_repo(node):
+    repos = node.get("repos") or {}
+    repo_nodes = repos.get("nodes") or []
+    return any(repo.get("id") for repo in repo_nodes)
+
+
+def export_opslevel_yml_files(selected_aliases, excluded_sections, dry_run=False):
+    end_cursor = None
+    has_next_page = True
+    skipped_count = 0
+    exported_count = 0
+
+    with open(SKIPPED_COMPONENTS_FILE, "w") as skipped_file:
+        while has_next_page:
+            response = opslevel_graphql_query(
+                LIST_SERVICES_QUERY, variables={"endCursor": end_cursor}
+            )
+            nodes = response["data"]["account"]["services"]["nodes"]
+            for node in nodes:
+                component_type = node["type"]["alias"]
+                if component_type not in selected_aliases:
+                    continue
+
+                if not has_linked_repo(node):
+                    skipped_file.write(f"{node['htmlUrl']}\n")
+                    skipped_count += 1
+                    continue
+
+                service_slug = node["slug"]
+                if dry_run:
+                    exported_count += 1
+                    print(
+                        f"[dry-run] Would export: "
+                        f"{component_type}/{service_slug}/opslevel.yml"
+                    )
+                    continue
+
+                service_id = node["id"]
+                response_2 = opslevel_graphql_query(
+                    FETCH_OPSLEVEL_YML_FOR_SERVICE_QUERY, variables={"id": service_id}
+                )
+                yaml_data = response_2["data"]["account"]["configFile"]["yaml"]
+                yaml_data = post_process_opslevel_yml(yaml_data, excluded_sections)
+                output_dir = os.path.join(OUTPUT_BASE_DIR, component_type, service_slug)
+                os.makedirs(output_dir, exist_ok=True)
+                output_path = os.path.join(output_dir, "opslevel.yml")
+                with open(output_path, "w") as f:
+                    f.write(yaml_data)
+                exported_count += 1
+
+            page_info = response["data"]["account"]["services"]["pageInfo"]
+            has_next_page = page_info["hasNextPage"]
+            end_cursor = page_info["endCursor"]
+
+    if dry_run:
+        print(
+            f"\n[dry-run] Would export {exported_count} component(s). "
+            f"No files written to {OUTPUT_BASE_DIR}."
+        )
+    else:
+        print(f"\nExported {exported_count} component(s) to {OUTPUT_BASE_DIR}.")
+
+    if skipped_count:
+        print(
+            f"Skipped {skipped_count} component(s) with no linked repo. "
+            f"See {SKIPPED_COMPONENTS_FILE}."
+        )
+
+
+def post_process_opslevel_yml(yaml_data, excluded_sections):
+    if "properties" not in excluded_sections:
+        return yaml_data
+
+    lines = yaml_data.splitlines(keepends=True)
+    result = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.rstrip("\n\r")
+        if stripped == "  properties:":
+            key_indent = 2
+            i += 1
+            while i < len(lines):
+                sibling = lines[i].rstrip("\n\r")
+                if sibling and (len(sibling) - len(sibling.lstrip(" "))) <= key_indent:
+                    break
+                i += 1
+            continue
+
+        result.append(line)
+        i += 1
+
+    return "".join(result)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Export OpsLevel opslevel.yml files for all components."
+    )
+    parser.add_argument(
+        "--include",
+        nargs="+",
+        choices=["properties"],
+        default=[],
+        metavar="SECTION",
+        help="Include optional YAML sections in the export (default: properties are excluded)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "List components that would be exported without writing opslevel.yml files. "
+            "Still writes skipped_components_with_missing_repo_links.txt."
+        ),
+    )
+    return parser.parse_args()
+
+
 # Main function to execute the script
 def main():
+    args = parse_args()
+    excluded_sections = DEFAULT_EXCLUDED_SECTIONS - set(args.include)
 
-    # Define your GraphQL queries
-    list_services_query = """
-        query get_services($endCursor:String){
-        account{
-            services(after: $endCursor){
-            nodes{
-                name
-                id
-            }
-            pageInfo{
-                hasNextPage
-                endCursor
-            }
-            }
-        }
-        }
-    """
+    component_types = fetch_default_component_types()
+    if not component_types:
+        print("No component types with category 'default' were found.", file=sys.stderr)
+        sys.exit(1)
 
-    fetch_opslevel_yml_for_service = """
-        query get_opslevel_yml($id:ID!) {
-        account {
-            configFile(id:$id) {
-            ownerType
-            yaml
-            }
-        }
-        }
-    """
-
-    # Make the first GraphQL query to get a list of items with pagination
-    cursor = None
-    has_next_page = True
-    while has_next_page:
-        response_1 = opslevel_graphql_query(
-            list_services_query, variables={"cursor": cursor}
-        )
-        nodes = response_1["data"]["account"]["services"]["nodes"]
-        for node in nodes:
-            service_id = node["id"]
-            service_name = node["name"]
-            variables = {"id": service_id}
-            # Make the second GraphQL query to get the yaml for each service
-            response_2 = opslevel_graphql_query(
-                fetch_opslevel_yml_for_service, variables
-            )
-            yaml_data = response_2["data"]["account"]["configFile"]["yaml"]
-            filename = f"{service_name}_opslevel.yml"
-            with open(filename, "a") as f:
-                f.write(yaml_data)
-
-        has_next_page = response_1["data"]["account"]["services"]["pageInfo"]["hasNextPage"]
-        cursor = response_1["data"]["account"]["services"]["pageInfo"]["endCursor"]
+    selected_aliases = prompt_component_type_selection(component_types)
+    if args.dry_run:
+        print("\n[dry-run] No opslevel.yml files will be written.")
+    print(f"\nExporting opslevel.yml for: {', '.join(sorted(selected_aliases))}")
+    export_opslevel_yml_files(selected_aliases, excluded_sections, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/scripts/export_all_opslevel_yml/opslevel_yml_export_for_all_services.py
+++ b/scripts/export_all_opslevel_yml/opslevel_yml_export_for_all_services.py
@@ -194,13 +194,11 @@ def export_opslevel_yml_files(
     no_repo_exported_count = 0
     exported_count = 0
 
-    skipped_file_context = (
-        open(SKIPPED_COMPONENTS_FILE, "w")
-        if not include_no_repo
-        else contextlib.nullcontext()
-    )
+    with contextlib.ExitStack() as stack:
+        skipped_file = None
+        if not include_no_repo:
+            skipped_file = stack.enter_context(open(SKIPPED_COMPONENTS_FILE, "w"))
 
-    with skipped_file_context as skipped_file:
         while has_next_page:
             response = opslevel_graphql_query(
                 LIST_SERVICES_QUERY, variables={"endCursor": end_cursor}
@@ -216,7 +214,7 @@ def export_opslevel_yml_files(
                     continue
 
                 missing_repo = not has_linked_repo(node)
-                if missing_repo and not include_no_repo:
+                if missing_repo and skipped_file is not None:
                     skipped_file.write(f"{node['htmlUrl']}\n")
                     skipped_count += 1
                     continue


### PR DESCRIPTION
Bulk-export OpsLevel opslevel.yml files to `opslevelyml_repo/<componentType>/<slug>/`, with component-type selection, optional no-repo export, properties stripping, dry-run preview, and a skipped-components report.

**Improve opslevel.yml export for bulk download and review.**

Exports auto-generated opslevel.yml files from OpsLevel into a local folder tree:

`opslevelyml_repo/<componentType>/<service_slug>/opslevel.yml`

**Choose what to export** - On run, pick component types interactively (e.g. `service, backend, frontend`) or pass `--component-types` service backend for scripts/CI.

**Filter by repo link** - By default, only components with a linked repository are exported. Components without one are skipped and listed in `skipped_components_with_missing_repo_links.txt`. Use `--include-no-repo` to export those too.

**Control YAML content** - The properties section is stripped by default. Use --include properties to keep it.

**Preview before writing** - `--dry-run` lists what would be exported without creating files under `opslevelyml_repo/`.

**Run summary** - Prints how many components were exported and how many were skipped (no linked repo).